### PR TITLE
Add missing actuator definitions to BrickLogic

### DIFF
--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_2d_filter.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_2d_filter.py
@@ -1,0 +1,36 @@
+# act_2d_filter.py
+
+actuator = {
+    "name": "Filter2DActuator",
+    "type": "actuator",
+    "description": "Applique un filtre 2D sur le rendu.",
+    "parameters": {
+        "mode": {
+            "type": "str",
+            "description": "Type de filtre à appliquer",
+            "enum": [
+                "CUSTOMFILTER",
+                "BLUR",
+                "SHARPEN",
+                "DESATURATE",
+                "INVERT",
+                "SEPIA",
+                "GAUSSIAN",
+                "LAPLACIAN",
+                "SOBEL",
+                "PREWITT"
+            ]
+        },
+        "pass_number": {
+            "type": "int",
+            "description": "Indice du filtre (pour l'ordre de traitement)",
+        },
+        "shader_text": {
+            "type": "str",
+            "description": "Nom du texte pour un filtre personnalisé",
+        }
+    },
+    "inputs": [
+        "trigger"
+    ]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_armature.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_armature.py
@@ -1,0 +1,35 @@
+# act_armature.py
+
+actuator = {
+    "name": "ArmatureActuator",
+    "type": "actuator",
+    "description": "Contrôle les actions d'une armature.",
+    "parameters": {
+        "action": {
+            "type": "str",
+            "description": "Nom de l'action à jouer",
+        },
+        "start_frame": {
+            "type": "int",
+            "description": "Frame de départ",
+        },
+        "end_frame": {
+            "type": "int",
+            "description": "Frame de fin",
+        },
+        "layer": {
+            "type": "int",
+            "description": "Calque cible",
+        },
+        "priority": {
+            "type": "int",
+            "description": "Priorité de l'action",
+        },
+        "mode": {
+            "type": "str",
+            "description": "Mode d'exécution",
+            "enum": ["PLAY", "STOP", "LOOP", "PINGPONG"]
+        }
+    },
+    "inputs": ["trigger"]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_game.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_game.py
@@ -1,0 +1,35 @@
+# act_game.py
+
+actuator = {
+    "name": "GameActuator",
+    "type": "actuator",
+    "description": "Contrôle l'exécution du jeu (quitter, redémarrer, charger...).",
+    "parameters": {
+        "mode": {
+            "type": "str",
+            "description": "Action à effectuer",
+            "enum": [
+                "START_GAME",
+                "RESTART_GAME",
+                "QUIT_GAME",
+                "LOAD_GAME",
+                "SAVE_GAME",
+                "SUSPEND_SCENE",
+                "RESUME_SCENE",
+                "SUSPEND_PHYSICS",
+                "RESUME_PHYSICS",
+                "SUSPEND_LOGIC",
+                "RESUME_LOGIC"
+            ]
+        },
+        "file_path": {
+            "type": "str",
+            "description": "Chemin du fichier pour START_GAME/LOAD_GAME/SAVE_GAME",
+        },
+        "scene_name": {
+            "type": "str",
+            "description": "Nom de la scène cible pour SUSPEND_SCENE ou RESUME_SCENE",
+        }
+    },
+    "inputs": ["trigger"]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_message.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_message.py
@@ -1,0 +1,30 @@
+# act_message.py
+
+actuator = {
+    "name": "MessageActuator",
+    "type": "actuator",
+    "description": "Envoie un message à d'autres objets.",
+    "parameters": {
+        "to": {
+            "type": "str",
+            "description": "Nom de l'objet destinataire (vide pour diffuser)",
+        },
+        "subject": {
+            "type": "str",
+            "description": "Sujet du message",
+        },
+        "body": {
+            "type": "str",
+            "description": "Contenu du message ou nom de propriété (selon body_type)",
+        },
+        "body_type": {
+            "type": "str",
+            "description": "Type de corps du message",
+            "enum": [
+                "STRING",
+                "PROPERTY"
+            ]
+        }
+    },
+    "inputs": ["trigger"]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_motion.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_motion.py
@@ -1,0 +1,35 @@
+# act_motion.py
+
+actuator = {
+    "name": "MotionActuator",
+    "type": "actuator",
+    "description": "Applique une transformation ou une vitesse à l'objet.",
+    "parameters": {
+        "mode": {
+            "type": "str",
+            "description": "Mode de déplacement",
+            "enum": ["SIMPLE", "SERVO"]
+        },
+        "dloc": {
+            "type": "vec3",
+            "description": "Déplacement local",
+        },
+        "drot": {
+            "type": "vec3",
+            "description": "Rotation locale",
+        },
+        "lin_velocity": {
+            "type": "vec3",
+            "description": "Vitesse linéaire",
+        },
+        "ang_velocity": {
+            "type": "vec3",
+            "description": "Vitesse angulaire",
+        },
+        "use_local": {
+            "type": "bool",
+            "description": "Interprète les valeurs en coordonnées locales",
+        }
+    },
+    "inputs": ["trigger"]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_parent.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_parent.py
@@ -1,0 +1,27 @@
+# act_parent.py
+
+actuator = {
+    "name": "ParentActuator",
+    "type": "actuator",
+    "description": "Change ou supprime le parent d'un objet.",
+    "parameters": {
+        "mode": {
+            "type": "str",
+            "description": "Opération à réaliser",
+            "enum": ["SET", "CLEAR"]
+        },
+        "parent": {
+            "type": "str",
+            "description": "Nom de l'objet parent (pour SET)",
+        },
+        "compound": {
+            "type": "bool",
+            "description": "Combine la physique avec le parent",
+        },
+        "ghost": {
+            "type": "bool",
+            "description": "Retire la collision de l'objet enfant",
+        }
+    },
+    "inputs": ["trigger"]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_property.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_property.py
@@ -1,0 +1,23 @@
+# act_property.py
+
+actuator = {
+    "name": "PropertyActuator",
+    "type": "actuator",
+    "description": "Modifie une propriété d'objet.",
+    "parameters": {
+        "property": {
+            "type": "str",
+            "description": "Nom de la propriété ciblée",
+        },
+        "mode": {
+            "type": "str",
+            "description": "Type de modification",
+            "enum": ["ASSIGN", "ADD", "COPY", "TOGGLE"]
+        },
+        "value": {
+            "type": "str",
+            "description": "Valeur ou nom de propriété source selon le mode",
+        }
+    },
+    "inputs": ["trigger"]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_random.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_random.py
@@ -1,0 +1,31 @@
+# act_random.py
+
+actuator = {
+    "name": "RandomActuator",
+    "type": "actuator",
+    "description": "Assigne une valeur aléatoire à une propriété.",
+    "parameters": {
+        "property": {
+            "type": "str",
+            "description": "Nom de la propriété ciblée",
+        },
+        "distribution": {
+            "type": "str",
+            "description": "Type de distribution aléatoire",
+            "enum": ["BOOL", "INT", "FLOAT"]
+        },
+        "min": {
+            "type": "float",
+            "description": "Valeur minimale",
+        },
+        "max": {
+            "type": "float",
+            "description": "Valeur maximale",
+        },
+        "seed": {
+            "type": "int",
+            "description": "Graine de génération",
+        }
+    },
+    "inputs": ["trigger"]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_scene.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_scene.py
@@ -1,0 +1,35 @@
+# act_scene.py
+
+actuator = {
+    "name": "SceneActuator",
+    "type": "actuator",
+    "description": "Gestion de la scène (ajout, suppression, suspension...).",
+    "parameters": {
+        "mode": {
+            "type": "str",
+            "description": "Action sur la scène",
+            "enum": [
+                "SET_SCENE",
+                "ADD_SCENE",
+                "REMOVE_SCENE",
+                "SUSPEND_SCENE",
+                "RESUME_SCENE",
+                "REPLACE_SCENE",
+                "SET_CAMERA"
+            ]
+        },
+        "scene": {
+            "type": "str",
+            "description": "Nom de la scène cible",
+        },
+        "camera": {
+            "type": "str",
+            "description": "Nom de la caméra pour SET_CAMERA",
+        },
+        "use_logic": {
+            "type": "bool",
+            "description": "Inclure la logique lors de l'ajout de scène",
+        }
+    },
+    "inputs": ["trigger"]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_sound.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_sound.py
@@ -1,0 +1,27 @@
+# act_sound.py
+
+actuator = {
+    "name": "SoundActuator",
+    "type": "actuator",
+    "description": "Joue un fichier audio.",
+    "parameters": {
+        "sound": {
+            "type": "str",
+            "description": "Nom du son ou chemin du fichier",
+        },
+        "mode": {
+            "type": "str",
+            "description": "Mode de lecture",
+            "enum": ["PLAY", "STOP", "LOOP", "PINGPONG", "END"]
+        },
+        "volume": {
+            "type": "float",
+            "description": "Volume de lecture",
+        },
+        "pitch": {
+            "type": "float",
+            "description": "Hauteur du son",
+        }
+    },
+    "inputs": ["trigger"]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_state.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_state.py
@@ -1,0 +1,19 @@
+# act_state.py
+
+actuator = {
+    "name": "StateActuator",
+    "type": "actuator",
+    "description": "Change l'état logique de l'objet.",
+    "parameters": {
+        "operation": {
+            "type": "str",
+            "description": "Mode de modification",
+            "enum": ["SET", "ADD", "SUB"]
+        },
+        "mask": {
+            "type": "int",
+            "description": "Masque d'état à appliquer",
+        }
+    },
+    "inputs": ["trigger"]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_steering.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_steering.py
@@ -1,0 +1,43 @@
+# act_steering.py
+
+actuator = {
+    "name": "SteeringActuator",
+    "type": "actuator",
+    "description": "Déplace un objet vers une cible en utilisant le pathfinding.",
+    "parameters": {
+        "target": {
+            "type": "str",
+            "description": "Nom de l'objet cible",
+        },
+        "navmesh": {
+            "type": "str",
+            "description": "Nom de l'objet navmesh",
+        },
+        "behavior": {
+            "type": "str",
+            "description": "Comportement de steering",
+            "enum": ["SEEK", "FLEE", "PATHFOLLOW", "PURSUIT", "EVASION"]
+        },
+        "distance": {
+            "type": "float",
+            "description": "Distance de freinage",
+        },
+        "speed": {
+            "type": "float",
+            "description": "Vitesse maximale",
+        },
+        "turn_speed": {
+            "type": "float",
+            "description": "Vitesse de rotation",
+        },
+        "acceleration": {
+            "type": "float",
+            "description": "Accélération maximale",
+        },
+        "enable_visualization": {
+            "type": "bool",
+            "description": "Active la visualisation du chemin",
+        }
+    },
+    "inputs": ["trigger"]
+}

--- a/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_visibility.py
+++ b/UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_visibility.py
@@ -1,0 +1,22 @@
+# act_visibility.py
+
+actuator = {
+    "name": "VisibilityActuator",
+    "type": "actuator",
+    "description": "Affiche ou cache un objet et ses enfants.",
+    "parameters": {
+        "visible": {
+            "type": "bool",
+            "description": "Rend l'objet visible ou invisible",
+        },
+        "occlusion": {
+            "type": "bool",
+            "description": "Active l'occlusion de l'objet",
+        },
+        "children": {
+            "type": "bool",
+            "description": "Applique aussi aux enfants",
+        }
+    },
+    "inputs": ["trigger"]
+}


### PR DESCRIPTION
## Summary
- add Filter2D actuator definition
- add missing actuator entries: Game, Message, Motion, Parent, Property, Random, Scene, Sound, State, Steering, Visibility, Armature

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_2d_filter.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_game.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_message.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_motion.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_parent.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_property.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_random.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_scene.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_sound.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_state.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_steering.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_visibility.py' 'UpbgeWebLab/blender_plugin/LogicBrick Dictionnary /act_armature.py'`


------
https://chatgpt.com/codex/tasks/task_e_68975ba3954c832eaffb99e8ec9e594c